### PR TITLE
Ready for the first run, Round Robin Chaos available.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,58 @@
-# chaos
-A framework for testing Minio's fault tolerance capability.
+# minio-chaos
+Chaos framework for testing Minio's fault tolerance capability.
+
+
+# Initial Design 
+
+ - Contains master and worker programs. Worker has be run on every node along with the Minio server and 
+   Master commands the chaos-workers on the remote nodes.
+ - The master program pings the chaos workers across nodes and ensures
+   that they are running and the choas workers in turn verify that the Minio
+   server is running on the remote node at the specified port during initialization.
+ - On the event of any chaos worker not reachable or if the Minio
+   process is not running on the remote node the test fails.
+ - Currrently RoundRobin Chaos Test is introduced wherein Minio server is
+   stopped on each node and recovered after the specified recovery time one after the other.
+   
+# How to run. 
+
+- Fetch the project 
+
+  `$go get github.com/hackintoshrao/minio-chaos` 
+- Build master program.
+
+  `$ cd $GOPATH/src/github.com/hackintoshrao/minio-chaos/master && go build`
+- Run Minio Distributed server using systemd script on remote nodes. 
+  The workers use `systemd` to control the Minio process. [Click here](https://github.com/minio/minio/tree/master/dist/linux-systemd/distributed) for info on configuring systemd to run Minio Distributed.
+- Build and run chaos-workers on each these remote nodes. Use `sudo` to run worker. 
+  Need privilaged access to control Minio process using systemd.
+  
+  `$ go get github.com/hackintoshrao/minio-chaos`
+  
+  `$ cd $GOPATH/src/github.com/hackintoshrao/minio-chaos/worker/ && go build`
+  
+  `$ sudo ./worker`
+- Run master. 
+  `master -endpoints="<Node-1-IP>:9997,<NODE-2-IP>:9997,<NODE-3-IP>:9997...... -recover=30"`
+   Currenly Chaos workers run at port 9997.
+   
+  
+  
+
+# Options
+
+- `-recover : Removery time after the failure injection on remote Minio node`.
+
+- `-endpoints: "," separted <IP>:<PORT> at which Remote Chaos Workers are Running"`.
+
+
+# What next ?
+
+- By Extending the `Chaos` interface different failures can be introduced. Next step is to make it more easier to run 
+  , with more options and different failures like multiple node failures will introduced.
+  
+# Contributing. 
+
+- Feel free to open and issue or send a PR.
+
+

--- a/master/chaos-test-rpc-handlers.go
+++ b/master/chaos-test-rpc-handlers.go
@@ -1,0 +1,23 @@
+/*
+ * Minio Cloud Storage, (C) 2015, 2016 Minio, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package main
+
+func (chaos *ChaosTest) InitChaosWorkerResponse(args *string, reply *int) error {
+	i := 0
+	*reply = i
+	return nil
+}

--- a/master/chaos-test.go
+++ b/master/chaos-test.go
@@ -1,0 +1,75 @@
+/*
+ * Minio Cloud Storage, (C) 2015, 2016 Minio, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package main
+
+import (
+	"log"
+)
+
+type ChaosTest struct {
+	ChaosWorkers []*ChaosWorker
+	RecoveryTime int
+}
+
+func (chaos *ChaosTest) InitChaosWorker(args *string, reply *int) error {
+	*reply = 0
+	return nil
+}
+
+// Ping all the workers via net/rpc, make sure they are reachable and running,
+// these workers on the nodes will also make sure Minio servers too are running on these nodes,
+// In the event of any chaos worker not reachable or Minio server not running on these nodes it'll return error
+// and the chaos test will be aborted.
+func (chaos *ChaosTest) InitChaosTest() bool {
+	// TODO: Code goes here.
+
+	var errorOccured bool
+	// Iterate through all the chaos workers on remote nodes.
+	// Communicate with them using RPC.
+	// Don't stop the process if any of the workers return error on RPC call.
+	// Log all the errors.
+	// If there's no error RPC client will returned, assign it to worker.Client for
+	// any further RPC communication with the workers on remote nodes.
+	for _, worker := range chaos.ChaosWorkers {
+		log.Println("Initializing worker at: ", worker.WorkerEndpoint)
+		// Communicate with remote chaos worker.
+		// The worker will also verify whether Minio server is running on their respective nodes and in the specified port.
+		rpcClient, err := worker.InitChaos()
+		// don't return in the event of an error.
+		// log the errors from all nodes before returning.
+		if err != nil {
+			// flag that an error occured in the remote node.
+			errorOccured = true
+			// log the error.
+			log.Printf("Error from Node %s: <ERROR> %v.", worker.WorkerEndpoint, err)
+		}
+		worker.Client = rpcClient
+
+	}
+	return errorOccured
+}
+
+// UnleshChaos - Recieves the `Chaos` interface which has methods for intruducing failure/recovery and calls it.
+func (chaos *ChaosTest) UnleashChaos(failTest Chaos) error {
+	// TODO: Code goes here.
+	var err error
+	// Call the execute Method of the Chaos interface.
+	err = failTest.Execute(*chaos)
+
+	return err
+
+}

--- a/master/chaos-worker.go
+++ b/master/chaos-worker.go
@@ -1,0 +1,66 @@
+/*
+ * Minio Cloud Storage, (C) 2015, 2016 Minio, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package main
+
+import (
+	"fmt"
+	"net/rpc"
+)
+
+// workerConfig contains info about the chaos workers running on nodes to be tested for fault tolerance.
+// Also contains info about Minio server instance running on these machines.
+type ChaosWorker struct {
+	// Endpoint of the chaos worker.
+	WorkerEndpoint string
+	// Info of the Minio Server Instance running on the node of the chaos worker.
+	Node MinioNode
+	// RPC client for communicating the worker.
+	Client *rpc.Client
+	// Directory in which the chaos worker dumps the report.
+	ReportDir string
+}
+
+// InitChaos - Pings the Chaos worker on the remote node via RPC and initializes it.
+//             Also checks whether Minio server instance is running on the specified port on the remote node.
+//             Reports failure if either the chaos-worker on the remote node is not reachable or Minio server
+// 	       is not running on the specified port on the remote node.
+func (chaos ChaosWorker) InitChaos() (*rpc.Client, error) {
+	// TODO: Code goes here.
+	// Tries to connect to worker on the remote node using HTTP protocol (The port on which rpc server is listening)
+	client, err := rpc.DialHTTP("tcp", chaos.WorkerEndpoint)
+	if err != nil {
+		return nil, fmt.Errorf("%s <Note> Make sure that the worker is running at %s", err.Error(), chaos.WorkerEndpoint)
+	}
+	minioRemoteAddr := chaos.Node.Addr
+	args := &minioRemoteAddr
+	reply := struct{}{}
+	// Call the `InitChaosWorker` RPC method on the remote worker.
+	// The worker verifies if the Minio server is running on the specified port on the remote node.
+	err = client.Call("ChaosWorker.InitChaosWorker", args, &reply)
+	// return in case of error.
+	if err != nil {
+		return nil, err
+	}
+	// return the RPC client for further interation with the worker on the remote nod// return the RPC client for further interation with the worker on the remote node.e.
+	return client, nil
+}
+
+// ReportStatus - Obtain the Status of the Minio node and choas-worker using the RPC call.
+func (chaos ChaosWorker) ReportStatus() {
+
+	// TODO: Code goes here.
+}

--- a/master/chaos.go
+++ b/master/chaos.go
@@ -1,0 +1,110 @@
+/*
+ * Minio Cloud Storage, (C) 2015, 2016 Minio, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package main
+
+import (
+	"log"
+	"time"
+)
+
+// Interface to which any choas function should satisfy.
+type Chaos interface {
+	// Responsible for calling the relevant failure method on the remote node.
+	// Should result in failure injection on the Minio server on the remote node.
+	Fail(c ChaosWorker) error
+	// Responsible for recovering the previsouly injected failure on the remote node.
+	Recover(c ChaosWorker) error
+	// Executes
+	Execute(t ChaosTest) error
+}
+
+// Has Methods,
+// * `Fail` - To stop Minio server on the remote node.
+// * `Recover` - To start Minio server on the remote node.
+// ^^ These are the most basic Fail and Recover functions.
+type GenericFail struct {
+}
+
+func (fail GenericFail) Fail(c ChaosWorker) error {
+	var err error
+	// Address containing info of the port at which Minio has to be run
+	// on the remote node of the worker.
+	minioRemoteAddr := c.Node.Addr
+	args := &minioRemoteAddr
+	// expecting only error response from the RPC call.
+	// not relying on the reply.
+	reply := struct{}{}
+	// Stop the Minio server on the remote node.
+	log.Println("Attempting to stop Minio server on node: ", c.WorkerEndpoint)
+	err = c.Client.Call("ChaosWorker.StopMinioServer", args, &reply)
+	if err == nil {
+		log.Println("Minio server stopped on node: ", c.WorkerEndpoint)
+	}
+	return err
+}
+
+// Most basic recovery on the remote node,
+// Starts the Minio server on the remote node.
+// Used to used to recover after the `Fail` method is called.
+func (fail GenericFail) Recover(c ChaosWorker) error {
+	var err error
+	// Address containing info of the port at which Minio has to be run
+	// on the remote node of the worker.
+	minioRemoteAddr := c.Node.Addr
+	args := &minioRemoteAddr
+	// expecting only error response from the RPC call.
+	// not relying on the reply.
+	reply := struct{}{}
+
+	log.Println("Attempting to Start Minio server on node: ", c.WorkerEndpoint)
+	// start the Minio server on the remote node.
+	err = c.Client.Call("ChaosWorker.StartMinioServer", args, &reply)
+	// Successfully started Minio server on the remote node,
+	// log the result.
+	if err == nil {
+		log.Println("Minio server Started on node: ", c.WorkerEndpoint)
+	}
+	return err
+}
+
+// Introduce Failure and Remove each remote node one by one.
+// There's a delay of specified time period between failure and removery of a node.
+type RoundRobinChaos struct {
+	GenericFail
+}
+
+// Iterates over all Choas workers,
+func (round *RoundRobinChaos) Execute(chaos ChaosTest) error {
+	var err error
+	for _, worker := range chaos.ChaosWorkers {
+		// TODO: Remove Sleep and introduce Context/Timeout and signalling methods to improve the logic.
+		// Call the Fail method to introduce failure on the remote node.
+		err = round.Fail(*worker)
+		if err != nil {
+			return err
+		}
+		// TODO: Use a better logic than just to sleep.
+		// Sleep for the time interval set for the failure recovery.
+		time.Sleep(time.Duration(chaos.RecoveryTime) * time.Second)
+		// Call the `Recover` Method to recover from the previously introduced failure on the remote node.
+		err = round.Recover(*worker)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/master/main.go
+++ b/master/main.go
@@ -1,0 +1,80 @@
+/*
+ * Minio Cloud Storage, (C) 2015, 2016 Minio, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package main
+
+import (
+	"flag"
+	"log"
+	"strconv"
+	"strings"
+)
+
+const (
+	MinioDefaultAddr = "http://127.0.0.1:9000"
+)
+
+func main() {
+	// TODO: parse all the flags here.
+	endPointStr := flag.String("endpoints", "", "RPC endpoints of workers.")
+	recoverStr := flag.String("recover", "10", "Recovery time of the remote node after Choas.")
+	// parse the command line flags.
+	flag.Parse()
+	endPoints := strings.Split(*endPointStr, ",")
+
+	chaosWorkers := make([]*ChaosWorker, len(endPoints))
+
+	// Iterate through the endPoints and create `ChaosTest` instance.
+	for i, endPoint := range endPoints {
+		worker := ChaosWorker{
+			WorkerEndpoint: endPoint,
+			Node: MinioNode{
+				Addr: MinioDefaultAddr,
+			},
+			//TODO: Make use of report Dir.
+			ReportDir: "/not-used-yet",
+		}
+		// push all the workers into the array.
+		chaosWorkers[i] = &worker
+	}
+
+	recoveryTime, err := strconv.Atoi(*recoverStr)
+	if err != nil {
+		log.Fatalf("Please enter valid time string for recovery: ", err)
+	}
+	// Create `ChaosTest` instance here.
+	chaosTest := ChaosTest{
+		ChaosWorkers: chaosWorkers,
+		RecoveryTime: recoveryTime,
+	}
+
+	// Initialize all the workers on remote nodes.
+	// also confirms that minio server instances are running on the remote nodes.
+	if isFailed := chaosTest.InitChaosTest(); isFailed {
+		log.Fatal("Iniitalizing of Chaos test failed.")
+	}
+
+	log.Println("Initialization finished, Starting Chaos test.")
+
+	// For extending the tests, any new chaos test has to satisfy `Chaos` interface,
+	// `RoundRobinChaos` satisfies the `Chaos` interface and it Fails the nodes and recovers them
+	// one after another in round robin fashion.
+	roundRobinChaos := &RoundRobinChaos{}
+	err = chaosTest.UnleashChaos(roundRobinChaos)
+	if err != nil {
+		log.Fatal("Chaos test failed with error: ", err)
+	}
+}

--- a/master/node.go
+++ b/master/node.go
@@ -1,0 +1,22 @@
+/*
+ * Minio Cloud Storage, (C) 2015, 2016 Minio, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package main
+
+// MinioNode - info of the Minio node under chaos test.
+type MinioNode struct {
+	Addr string
+}

--- a/master/report.go
+++ b/master/report.go
@@ -1,0 +1,104 @@
+/*
+ * Minio Cloud Storage, (C) 2015, 2016 Minio, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+	"sync"
+	"time"
+	//	"github.com/prometheus/client_golang/prometheus"
+)
+
+const (
+	serverUp   = "Server Running"
+	serverDown = "Server Stopped by Worker"
+)
+
+// experimenting with prometheus for counters in the project.
+// will move onto use other features it this looks good.1
+//var StoppedNodesCounter = prometheus.NewCounter(
+//	prometheus.CounterOpts{
+//		Namespace: "Minio",
+//		Subsystem: "Minio-Chaos-Test",
+//		Name:      "StoppedNodesCounter",
+//		Help:      "Total number of Nodes Stopped by Chaos workers currently",
+//	})
+
+// register the prometheus service.
+func init() {
+	//prometheus.MustRegister(StoppedNodesCounter)
+}
+
+// Report - contains fields to keep the status of the chaos test across all chaos workers on all nodes.
+// Here are some of the expected fields in the report.
+// Since - Time since the test is running.
+// ServerStatus - Contains the status of the Minio server on the nodes where the chaos worker is running.
+// 		  Since the chaos worker stops the server and restarts after a definate interval, the status helps to whether
+//                the Minio server is running or has been stopped by the
+// 		  chaos worker.
+type Report struct {
+	// Lock to be used before mutating any field of the status.
+	sync.Mutex
+	// Add all necessary fields to report the status of the chaos operations.
+	TestRunningSince time.Time
+	// Status of all the Minio servers.
+	// Obtaining by visiting `/report` of the master process of the chaos test.
+	Status []ServerStatus
+}
+
+// ServerStatus - Field to store the status of the Minio server running on the nodes.
+type ServerStatus struct {
+	// Addr of the Minio Server Node.
+	MinioAddr string
+	// status is either "serverUp" or "serverDown".
+	Status string
+	// Time since the above status holds.
+	StatusSince time.Time
+	// The next expected change in status of the Node.
+	NextChange string
+	// Time aftedr which the status change can be expected.
+	NextChangeIn time.Time
+}
+
+// Wraps the status report of the test and exposes HTTP handler interface for
+// viewing the status.
+
+type reportHandler struct {
+	report *Report
+}
+
+// HTTP handler which fetches the status of all the nodes during the chaos test.
+// Pings all the chaos workers and obtain the status of the Minio nodes.
+// Once the status obtained write it to as a HTTP response.
+func (rep reportHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+	en := json.NewEncoder(w)
+
+	rep.report.Lock()
+	defer rep.report.Unlock()
+
+	// TODO: Ping all the chaos workers and obtain the status of the Minio nodes.
+	// Once the status obtained write it to as a HTTP response.
+
+	if err := en.Encode(Report{
+
+	// other parameters to be reported goes here.
+	}); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+	}
+}

--- a/worker/chaos-worker.go
+++ b/worker/chaos-worker.go
@@ -1,0 +1,107 @@
+/*
+ * Minio Cloud Storage, (C) 2015, 2016 Minio, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package main
+
+import (
+	"fmt"
+	"log"
+	"net/http"
+	"net/rpc"
+	"os/exec"
+	"strings"
+)
+
+type Worker struct {
+}
+
+// Tests whether Minio is running on the node in the specified port.
+// Send a GEr request and find out whether the header contains string `Minio` in it.
+func IsMinioRunning(addr string) error {
+	// error to be returned to the master if Minio server is not reachable on the node.
+	var errRunMinioServer = fmt.Errorf("Run Minio on %s and start the test again.", addr)
+	// send GET request to the specified port.
+	resp, err := http.Get(addr)
+	// Errors out if server is not running at the specified port.
+	// return error to the RPC request.
+	if err != nil {
+		log.Println(err)
+		return errRunMinioServer
+	}
+	log.Println(resp.Header.Get("Server"))
+	// check if the server running is Minio server.
+	// this is done by checking for string `Minio` is the `Server` header of the response.
+	if !strings.Contains(resp.Header.Get("Server"), "Minio") {
+		return errRunMinioServer
+	}
+	// success, return the error to be `nil` to the RPC request.
+	return nil
+}
+
+// Starts the Minio server using `systemd` when master call it over RPC/
+func (w *Worker) StartMinioServer(args *string, reply *struct{}) error {
+	cmd := exec.Command("service", "minio", "start")
+
+	err := cmd.Start()
+	if err != nil {
+		log.Println("Failed to Start the Minio Server using the systemd script: <ERROR> ", err)
+		return err
+	}
+	log.Println("Started Minio server using `service minio stop`.")
+	cmd.Wait()
+	return nil
+}
+
+// Stops the Minio server using `systemd` when master call it over RPC/
+func (w *Worker) StopMinioServer(args *string, reply *struct{}) error {
+	cmd := exec.Command("service", "minio", "stop")
+
+	err := cmd.Start()
+	if err != nil {
+		log.Println("Failed to Stop the Minio Server using the systemd script: <ERROR> ", err)
+		return err
+	}
+	log.Println("Stopped Minio server using `service minio stop`.")
+	cmd.Wait()
+	return nil
+}
+
+// Initialize the worker for the chaos test.
+// A `nil` error response indicates the master that the worker and Minio server is running on the specified port.
+func (w *Worker) InitChaosWorker(args *string, reply *struct{}) error {
+	log.Println("Initializing the Node for the Chaos test.")
+	// Verifies whether Minio is running on the specified port.
+	err := IsMinioRunning(*args)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func main() {
+	// obtain ServeMux to register the RPC service.
+	mux := http.NewServeMux()
+	// chaos worker configuration.
+	worker := &Worker{}
+	// Creating a new instance of the RPC server.
+	rpcServer := rpc.NewServer()
+	// Registering the RPC handler.
+	rpcServer.RegisterName("ChaosWorker", worker)
+	// Regsitering the RPC service.
+	mux.Handle("/", rpcServer)
+	// Run the server.
+	http.ListenAndServe(":9997", mux)
+}


### PR DESCRIPTION
- Master communicates with all the workers and ensures that the workers
  and the Minio server is running on the remote nodes during the
  initialization.
- Currrently RoundRobin Chaos Test is introduced wherein Minio server is
  stopped on each node and recovered after the specified recovery time
  one after the other.
- Extend the tests by satisfying the chaos interface.
