### PR TITLE
Flag to specify the port at which Minio is running on remote node.

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ $ sudo ./worker
 - Run master. 
 
 ```sh
-$ master -endpoints="<Node-1-IP>:9997,<NODE-2-IP>:9997,<NODE-3-IP>:9997...... -recover=30 -rounds=10"
+$ master -endpoints="<Node-1-IP>:9997,<NODE-2-IP>:9997,<NODE-3-IP>:9997...... -recover=30 -rounds=10 -minio-port=9199"
 ```
 
 Chaos workers will be running at port "9997" now.   
@@ -46,12 +46,16 @@ Chaos workers will be running at port "9997" now.
 -recover : Removery time after the failure injection on remote Minio node.
 ```
 
-```
+```sh
 -endpoints: "," separted <IP>:<PORT> at which Remote Chaos Workers are Running".
 ```
 
-```
+```sh
 -rounds: Number of rounds the chaos test has to be run.
+```
+
+```sh
+-minio-port: Port at which Minio server is running on remote node. Port 9000 is taken as the default value if no value is provided. 
 ```
 
 # TODO

--- a/master/main.go
+++ b/master/main.go
@@ -23,19 +23,37 @@ import (
 	"strings"
 )
 
-const (
-	MinioDefaultAddr = "http://127.0.0.1:9000"
-)
+// verify whether the Minio server port is a valid integer.
+func verifyMinioPort(portStr string) error {
+	_, err := strconv.Atoi(portStr)
+	if err != nil {
+		return err
+	}
+	return nil
+}
 
 func main() {
 	// TODO: parse all the flags here.
 	endPointStr := flag.String("endpoints", "", "RPC endpoints of workers.")
 	recoverStr := flag.String("recover", "10", "Recovery time of the remote node after Choas.")
 	roundsStr := flag.String("rounds", "1", "Number of rounds the Choas test has to be run.")
+	// Port at which Minio server is run on remote nodes.
+	// Default Minio server port of 9000 is taken as the default option.
+	minioPortStr := flag.String("minio-port", "9000", "Port at which Minio server is run on remote nodes.")
 	// parse the command line flags.
 	flag.Parse()
+	// obtain all the node end points.
 	endPoints := strings.Split(*endPointStr, ",")
+	// verify whether a valid integer port is given.
+	if err := verifyMinioPort(*minioPortStr); err != nil {
+		log.Fatalf("Please enter a valid integer port at which Minio server is running on remote nodes.")
+	}
 
+	// minioAddr - will be used by workers on the respective remote nodes to verify whether Minio is running as a service
+	// before the chaos test is started.
+	minioAddr := "http://127.0.0.1:" + *minioPortStr
+	// Allocate memory for ChaosWorkers.
+	// Allocating one for each node.
 	chaosWorkers := make([]*ChaosWorker, len(endPoints))
 
 	// Iterate through the endPoints and create `ChaosTest` instance.
@@ -43,7 +61,7 @@ func main() {
 		worker := ChaosWorker{
 			WorkerEndpoint: endPoint,
 			Node: MinioNode{
-				Addr: MinioDefaultAddr,
+				Addr: minioAddr,
 			},
 			//TODO: Make use of report Dir.
 			ReportDir: "/not-used-yet",


### PR DESCRIPTION
- Currently it was assumed that Minio is running on default port 9000 on all remote nodes.
- Now with the flag `minio-port`, one could specify the port at which Minio server is running.
- This helps to chaos test the Minio server running on non-default port.