### PR TITLE
Start Minio server on remote nodes only on -start-minio flag.

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,9 @@ Chaos workers will be running at port "9997" now.
 -minio-port: Port at which Minio server is running on remote node. Port 9000 is taken as the default value if no value is provided. 
 ```
 
+```sh
+-start-minio: Starts Minio server on remote nodes during initialization of the chaos test. 
+```
 # TODO
 
 - By Extending the `Chaos` interface different failures can be introduced. Next step is to make it more easier to run, with more options and different failures like multiple node failures will introduced.

--- a/master/chaos-worker.go
+++ b/master/chaos-worker.go
@@ -19,6 +19,8 @@ package main
 import (
 	"fmt"
 	"net/rpc"
+
+	"github.com/minio/chaos/shared"
 )
 
 // workerConfig contains info about the chaos workers running on nodes to be tested for fault tolerance.
@@ -27,7 +29,7 @@ type ChaosWorker struct {
 	// Endpoint of the chaos worker.
 	WorkerEndpoint string
 	// Info of the Minio Server Instance running on the node of the chaos worker.
-	Node MinioNode
+	Node shared.MinioNode
 	// RPC client for communicating the worker.
 	Client *rpc.Client
 	// Directory in which the chaos worker dumps the report.
@@ -45,8 +47,7 @@ func (chaos ChaosWorker) InitChaos() (*rpc.Client, error) {
 	if err != nil {
 		return nil, fmt.Errorf("%s <Note> Make sure that the worker is running at %s", err.Error(), chaos.WorkerEndpoint)
 	}
-	minioRemoteAddr := chaos.Node.Addr
-	args := &minioRemoteAddr
+	args := &chaos.Node
 	reply := struct{}{}
 	// Call the `InitChaosWorker` RPC method on the remote worker.
 	// The worker verifies if the Minio server is running on the specified port on the remote node.

--- a/master/main.go
+++ b/master/main.go
@@ -21,6 +21,8 @@ import (
 	"log"
 	"strconv"
 	"strings"
+
+	"github.com/minio/chaos/shared"
 )
 
 // verify whether the Minio server port is a valid integer.
@@ -37,6 +39,8 @@ func main() {
 	endPointStr := flag.String("endpoints", "", "RPC endpoints of workers.")
 	recoverStr := flag.String("recover", "10", "Recovery time of the remote node after Choas.")
 	roundsStr := flag.String("rounds", "1", "Number of rounds the Choas test has to be run.")
+	startMinioPtr := flag.Bool("start-minio", false, "flag indicating whether Minio has to be started on remote nodes.")
+
 	// Port at which Minio server is run on remote nodes.
 	// Default Minio server port of 9000 is taken as the default option.
 	minioPortStr := flag.String("minio-port", "9000", "Port at which Minio server is run on remote nodes.")
@@ -60,8 +64,9 @@ func main() {
 	for i, endPoint := range endPoints {
 		worker := ChaosWorker{
 			WorkerEndpoint: endPoint,
-			Node: MinioNode{
-				Addr: minioAddr,
+			Node: shared.MinioNode{
+				Addr:       minioAddr,
+				StartMinio: *startMinioPtr,
 			},
 			//TODO: Make use of report Dir.
 			ReportDir: "/not-used-yet",

--- a/shared/node.go
+++ b/shared/node.go
@@ -14,9 +14,17 @@
  * limitations under the License.
  */
 
-package main
+// Package  containing shared data structure between master and the workers.
+package shared
 
 // MinioNode - info of the Minio node under chaos test.
 type MinioNode struct {
+	// flag indicating whether Minio node has to started.
+	// unless specifed with a `-start` flag an attempt to start Minio server
+	// on the remote node is done.`
+	StartMinio bool
+	// Adress of format 127.0.0.1:<PORT>,
+	// Used to validate whether Minio server is running on each of the nodes
+	// in the specified port.
 	Addr string
 }


### PR DESCRIPTION
Fixes https://github.com/minio/chaos/issues/12 . 