### PR TITLE
Check health of the node after each round of the chaos test.

### DIFF
--- a/master/chaos-worker.go
+++ b/master/chaos-worker.go
@@ -60,6 +60,20 @@ func (chaos ChaosWorker) InitChaos() (*rpc.Client, error) {
 	return client, nil
 }
 
+func (chaos ChaosWorker) CheckMinioHealth() error {
+	args := &chaos.Node.Addr
+	reply := struct{}{}
+	// Call the `InitChaosWorker` RPC method on the remote worker.
+	// The worker verifies if the Minio server is running on the specified port on the remote node.
+	err := chaos.Client.Call("ChaosWorker.CheckMinioHealth", args, &reply)
+	// return in case of error.
+	if err != nil {
+		return err
+	}
+	// Health of Minio server on the remote node is fine.
+	return nil
+}
+
 // ReportStatus - Obtain the Status of the Minio node and choas-worker using the RPC call.
 func (chaos ChaosWorker) ReportStatus() {
 

--- a/master/main.go
+++ b/master/main.go
@@ -115,5 +115,13 @@ func main() {
 		if err != nil {
 			log.Fatal("Chaos test failed with error: ", err)
 		}
+		log.Println("Round %d ", j+1, " test complete, verifying health of the nodes.")
+		// Verify health of the nodes after each round of test.
+		// Abort in case in any of the nodes failed to restart during chaos test.
+		nodesDown := chaosTest.CheckNodeHealth()
+		if nodesDown {
+			log.Fatal("One or more nodes failed to restart, aborting chaos test")
+		}
+		log.Println("All nodes are up.")
 	}
 }

--- a/worker/chaos-worker.go
+++ b/worker/chaos-worker.go
@@ -93,6 +93,17 @@ func (w *Worker) StopMinioServer(args *string, reply *struct{}) error {
 	return nil
 }
 
+// Check whether Minio server is up.
+func (w *Worker) CheckMinioHealth(args *string, reply *struct{}) error {
+	log.Println("Initializing the Node for the Chaos test.")
+	// Verifies whether Minio is running on the specified port.
+	err := IsMinioRunning(*args)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
 // Initialize the worker for the chaos test.
 // Starts the Minio server is master is ran with `-start-minio` argument.
 // And then verify whether starting Minio was succesfull.


### PR DESCRIPTION
- Check health of all nodes after each round of test.
- Helps to make sure that any failure of the nodes doesn't go unnoticed.
- fixes https://github.com/minio/chaos/issues/11 . 